### PR TITLE
switch back to go-stack/stack

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -83,7 +83,7 @@ import (
 	"github.com/getlantern/context"
 	"github.com/getlantern/hidden"
 	"github.com/getlantern/ops"
-	"github.com/getlantern/stack"
+	"github.com/go-stack/stack"
 )
 
 // Error wraps system and application defined errors in unified structure for


### PR DESCRIPTION
The only reason to fork it is to add `%k` https://github.com/getlantern/stack/commit/02f928aad224fbccd50d66edd776fc9d1e9f2f2b, which is implemented by upstream at https://github.com/go-stack/stack/commit/68206431471b1917aed9574c25f032c23100004d

Fixes https://github.com/getlantern/systray/issues/57