### PR TITLE
Add support for error unwrapping

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -131,8 +131,6 @@ type baseError struct {
 	callStack stack.CallStack
 }
 
-// TODO: update doc as necessary
-
 // New creates an Error with supplied description and format arguments to the
 // description. If any of the arguments is an error, we use that as the cause.
 func New(desc string, args ...interface{}) Error {
@@ -166,12 +164,10 @@ func NewOffset(offset int, desc string, args ...interface{}) Error {
 // errors.Wrap(s.l.Close()) regardless there's an error or not. If the error is
 // already wrapped, it is returned as is.
 func Wrap(err error) Error {
-	// TODO: consider whether Wrap could simply be an alias for New
-
 	if err == nil {
 		return nil
 	}
-	if e, ok := err.(*baseError); ok {
+	if e, ok := err.(Error); ok {
 		return e
 	}
 

--- a/errors.go
+++ b/errors.go
@@ -349,6 +349,19 @@ func (e *wrappingError) MultiLinePrinter() func(*bytes.Buffer) bool {
 	}
 }
 
+// We have to implement these methods or the fluid syntax will result in the embedded *baseError
+// being returned, not the *wrappingError.
+
+func (e *wrappingError) Op(op string) Error {
+	e.baseError = e.baseError.Op(op).(*baseError)
+	return e
+}
+
+func (e *wrappingError) With(key string, value interface{}) Error {
+	e.baseError = e.baseError.With(key, value).(*baseError)
+	return e
+}
+
 func getTopLevelPrinter(err error) func(*bytes.Buffer) bool {
 	if tlp, ok := err.(topLevelPrinter); ok {
 		return tlp.topLevelPrinter()

--- a/errors.go
+++ b/errors.go
@@ -123,15 +123,15 @@ type Error interface {
 	RootCause() error
 }
 
-type structured struct {
+type baseError struct {
 	id        uint64
 	hiddenID  string
 	data      context.Map
 	context   context.Map
-	wrapped   error
-	cause     Error
 	callStack stack.CallStack
 }
+
+// TODO: update doc as necessary
 
 // New creates an Error with supplied description and format arguments to the
 // description. If any of the arguments is an error, we use that as the cause.
@@ -142,16 +142,19 @@ func New(desc string, args ...interface{}) Error {
 // NewOffset is like New but offsets the stack by the given offset. This is
 // useful for utilities like golog that may create errors on behalf of others.
 func NewOffset(offset int, desc string, args ...interface{}) Error {
-	var cause error
+	e := buildError(desc, fmt.Sprintf(desc, args...))
+	e.attachStack(2 + offset)
 	for _, arg := range args {
-		err, isError := arg.(error)
+		wrapped, isError := arg.(error)
 		if isError {
-			cause = err
-			break
+			op, _, _, extraData := parseError(wrapped)
+			e.Op(op)
+			for k, v := range extraData {
+				e.data[k] = v
+			}
+			return &wrappingError{e, wrapped}
 		}
 	}
-	e := buildError(desc, fmt.Sprintf(desc, args...), nil, Wrap(cause))
-	e.attachStack(2 + offset)
 	return e
 }
 
@@ -160,33 +163,54 @@ func NewOffset(offset int, desc string, args ...interface{}) Error {
 // errors.Wrap(s.l.Close()) regardless there's an error or not. If the error is
 // already wrapped, it is returned as is.
 func Wrap(err error) Error {
-	return wrapSkipFrames(err, 1)
+	// TODO: consider whether Wrap could simply be an alias for New
+
+	if err == nil {
+		return nil
+	}
+	if e, ok := err.(*baseError); ok {
+		return e
+	}
+
+	op, goType, desc, extraData := parseError(err)
+	if desc == "" {
+		desc = err.Error()
+	}
+	e := buildError(desc, desc)
+	e.attachStack(2) // TODO: check skip=2
+	e.Op(op)
+	e.data["error_type"] = goType
+	for k, v := range extraData {
+		e.data[k] = v
+	}
+	if cause := getCause(err); cause != nil {
+		return &wrappingError{e, cause}
+	}
+	return e
 }
 
 // Fill implements the method from the context.Contextual interface.
-func (e *structured) Fill(m context.Map) {
-	if e != nil {
-		if e.cause != nil {
-			// Include data from cause, which supercedes context
-			e.cause.Fill(m)
-		}
-		// Include the context, which supercedes the cause
-		for key, value := range e.context {
-			m[key] = value
-		}
-		// Now include the error's data, which supercedes everything
-		for key, value := range e.data {
-			m[key] = value
-		}
+func (e *baseError) Fill(m context.Map) {
+	if e == nil {
+		return
+	}
+
+	// Include the context, which supercedes the cause
+	for key, value := range e.context {
+		m[key] = value
+	}
+	// Now include the error's data, which supercedes everything
+	for key, value := range e.data {
+		m[key] = value
 	}
 }
 
-func (e *structured) Op(op string) Error {
+func (e *baseError) Op(op string) Error {
 	e.data["error_op"] = op
 	return e
 }
 
-func (e *structured) With(key string, value interface{}) Error {
+func (e *baseError) With(key string, value interface{}) Error {
 	parts := strings.FieldsFunc(key, func(c rune) bool {
 		return !unicode.IsLetter(c) && !unicode.IsNumber(c)
 	})
@@ -204,127 +228,55 @@ func (e *structured) With(key string, value interface{}) Error {
 	return e
 }
 
-func (e *structured) RootCause() error {
-	if e.cause == nil {
-		if e.wrapped != nil {
-			return e.wrapped
-		}
-		return e
-	}
-	return e.cause.RootCause()
+func (e *baseError) RootCause() error {
+	return e
 }
 
-func (e *structured) ErrorClean() string {
+func (e *baseError) ErrorClean() string {
 	return e.data["error"].(string)
 }
 
 // Error satisfies the error interface
-func (e *structured) Error() string {
+func (e *baseError) Error() string {
 	return e.data["error_text"].(string) + e.hiddenID
 }
 
-func (e *structured) MultiLinePrinter() func(buf *bytes.Buffer) bool {
-	first := true
-	indent := false
-	err := e
+func (e *baseError) MultiLinePrinter() func(*bytes.Buffer) bool {
+	printingStack := false
 	stackPosition := 0
-	switchedCause := false
 	return func(buf *bytes.Buffer) bool {
-		if indent {
+		if printingStack {
 			buf.WriteString("  ")
-		}
-		if first {
+		} else {
 			buf.WriteString(e.Error())
-			first = false
-			indent = true
+			printingStack = true
 			return true
 		}
-		if switchedCause {
-			fmt.Fprintf(buf, "Caused by: %v", err)
-			if err.callStack != nil && len(err.callStack) > 0 {
-				switchedCause = false
-				indent = true
-				return true
-			}
-			if err.cause == nil {
-				return false
-			}
-			err = err.cause.(*structured)
-			return true
+		if stackPosition >= len(e.callStack) {
+			// Or should we have returned false from the last call?
+			return false
 		}
-		if stackPosition < len(err.callStack) {
-			buf.WriteString("at ")
-			call := err.callStack[stackPosition]
-			fmt.Fprintf(buf, "%+n (%s:%d)", call, call, call)
-			stackPosition++
-		}
-		if stackPosition >= len(err.callStack) {
-			switch cause := err.cause.(type) {
-			case *structured:
-				err = cause
-				indent = false
-				stackPosition = 0
-				switchedCause = true
-			default:
-				return false
-			}
-		}
-		return err != nil
+		buf.WriteString("at ")
+		call := e.callStack[stackPosition]
+		fmt.Fprintf(buf, "%+n (%s:%d)", call, call, call)
+		stackPosition++
+		return true
 	}
 }
 
-func wrapSkipFrames(err error, skip int) Error {
-	if err == nil {
-		return nil
-	}
-
-	// Look for *structureds
-	if e, ok := err.(*structured); ok {
-		return e
-	}
-
-	var cause Error
-	// Look for hidden *structureds
-	hiddenIDs, err2 := hidden.Extract(err.Error())
-	if err2 == nil && len(hiddenIDs) > 0 {
-		// Take the first hidden ID as our cause
-		cause = get(hiddenIDs[0])
-	}
-
-	// Create a new *structured
-	return buildError("", "", err, cause)
-}
-
-func (e *structured) attachStack(skip int) {
+func (e *baseError) attachStack(skip int) {
 	call := stack.Caller(skip)
 	e.callStack = stack.Trace().TrimBelow(call)
 	e.data["error_location"] = fmt.Sprintf("%+n (%s:%d)", call, call, call)
 }
 
-func buildError(desc string, fullText string, wrapped error, cause Error) *structured {
-	e := &structured{
+func buildError(desc string, fullText string) *baseError {
+	e := &baseError{
 		data: make(context.Map),
 		// We capture the current context to allow it to propagate to higher layers.
 		context: ops.AsMap(nil, false),
-		wrapped: wrapped,
-		cause:   cause,
 	}
 	e.save()
-
-	errorType := "errors.Error"
-	if wrapped != nil {
-		op, goType, wrappedDesc, extra := parseError(wrapped)
-		if desc == "" {
-			desc = wrappedDesc
-		}
-		e.Op(op)
-		errorType = goType
-		if extra != nil {
-			for key, value := range extra {
-				e.data[key] = value
-			}
-		}
-	}
 
 	cleanedDesc := hidden.Clean(desc)
 	e.data["error"] = cleanedDesc
@@ -333,8 +285,108 @@ func buildError(desc string, fullText string, wrapped error, cause Error) *struc
 	} else {
 		e.data["error_text"] = cleanedDesc
 	}
-	e.data["error_type"] = errorType
+	e.data["error_type"] = "errors.Error"
 
+	return e
+}
+
+type multiLinePrinter interface {
+	MultiLinePrinter() func(*bytes.Buffer) bool
+}
+
+type unwrapper interface {
+	Unwrap() error
+}
+
+type wrappingError struct {
+	*baseError
+	wrapped error
+}
+
+// Implements error unwrapping as described in the standard library's errors package:
+// https://golang.org/pkg/errors/#pkg-overview
+func (e *wrappingError) Unwrap() error {
+	return e.wrapped
+}
+
+func (e *wrappingError) Fill(m context.Map) {
+	type filler interface{ Fill(context.Map) }
+
+	if f, ok := e.wrapped.(filler); ok {
+		f.Fill(m)
+	}
+	e.baseError.Fill(m)
+}
+
+func (e *wrappingError) RootCause() error {
+	return unwrapToRoot(e)
+}
+
+// TODO: the next two functions could possibly be simplified
+
+func (e *wrappingError) MultiLinePrinter() func(*bytes.Buffer) bool {
+	currentPrinter := e.MultiLinePrinter()
+	return func(buf *bytes.Buffer) bool {
+		if currentPrinter(buf) {
+			return true
+		}
+		fmt.Fprint(buf, "Caused by: ")
+		if mlp, ok := e.wrapped.(multiLinePrinter); ok {
+			currentPrinter = mlp.MultiLinePrinter()
+		} else {
+			currentPrinter = createMultiLinePrinter(e.wrapped)
+		}
+		return currentPrinter(buf)
+	}
+}
+
+func createMultiLinePrinter(err error) func(*bytes.Buffer) bool {
+	var (
+		currentPrinter func(*bytes.Buffer) bool
+		currentErr     = err
+	)
+	if mlp, ok := err.(multiLinePrinter); ok {
+		currentPrinter = mlp.MultiLinePrinter()
+	}
+	return func(buf *bytes.Buffer) bool {
+		if currentPrinter == nil {
+			fmt.Fprint(buf, currentErr)
+		} else if currentPrinter(buf) {
+			return true
+		}
+		uw, ok := currentErr.(unwrapper)
+		if !ok {
+			// Base case: this is the root error.
+			return false
+		}
+		currentErr = uw.Unwrap()
+		if mlp, ok := currentErr.(multiLinePrinter); ok {
+			currentPrinter = mlp.MultiLinePrinter()
+		} else {
+			currentPrinter = nil
+		}
+		return true
+	}
+}
+
+func getCause(e error) error {
+	if uw, ok := e.(unwrapper); ok {
+		return uw.Unwrap()
+	}
+	// Look for hidden *baseErrors
+	// TODO: how do these get there? do we need to make sure wrappingErrors do the same?
+	hiddenIDs, extractErr := hidden.Extract(e.Error())
+	if extractErr == nil && len(hiddenIDs) > 0 {
+		// Take the first hidden ID as our cause
+		return get(hiddenIDs[0])
+	}
+	return nil
+}
+
+func unwrapToRoot(e error) error {
+	if uw, ok := e.(unwrapper); ok {
+		return unwrapToRoot(uw.Unwrap())
+	}
 	return e
 }
 

--- a/errors_test.go
+++ b/errors_test.go
@@ -104,7 +104,7 @@ func buildCause() Error {
 }
 
 func buildSubCause() error {
-	return fmt.Errorf("or%v", buildSubSubCause())
+	return fmt.Errorf("or%w", buildSubSubCause())
 }
 
 func buildSubSubCause() error {

--- a/errors_test.go
+++ b/errors_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/getlantern/hidden"
 	"github.com/getlantern/ops"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -31,7 +32,8 @@ func TestFull(t *testing.T) {
 		op = ops.Begin("op2").Set("ca", 200).Set("cb", 200).Set("cc", 200)
 		e3 := Wrap(fmt.Errorf("I'm wrapping your text: %v", e)).Op("outer op").With("dATA+1", i).With("cb", 300)
 		op.End()
-		assert.Equal(t, e, e3.(*structured).cause, "Wrapping a regular error should have extracted the contained *Error")
+		require.IsType(t, (*wrappingError)(nil), e3, "wrapping an error should have resulted in a *wrappingError")
+		assert.Equal(t, e, e3.(*wrappingError).wrapped, "Wrapping a regular error should have extracted the contained *Error")
 		m := make(context.Map)
 		e3.Fill(m)
 		assert.Equal(t, i, m["data_1"], "Error's data should dominate all")
@@ -39,26 +41,29 @@ func TestFull(t *testing.T) {
 		assert.Equal(t, 300, m["cb"], "Error's data should dominate its context")
 		assert.Equal(t, 200, m["cc"], "Error's context should come through")
 		assert.Equal(t, 100, m["cd"], "Cause's context should come through")
-		assert.Equal(t, "My Op", e.(*structured).data["error_op"], "Op should be available from cause")
+		assert.Equal(t, "My Op", e.(*baseError).data["error_op"], "Op should be available from cause")
 
-		for _, call := range e3.(*structured).callStack {
+		for _, call := range e3.(*baseError).callStack {
 			t.Logf("at %v", call)
 		}
 	}
 
 	e3 := Wrap(fmt.Errorf("I'm wrapping your text: %v", firstErr)).With("a", 2)
-	assert.Nil(t, e3.(*structured).cause, "Wrapping an *Error that's no longer buffered should have yielded no cause")
+	// TODO: is this correct? (replaces commented line below)
+	require.IsType(t, (*baseError)(nil), e3, "Wrapping an *Error that's no longer buffered should have resulted in a *baseError")
+	// assert.Nil(t, e3.(*baseError).cause, "Wrapping an *Error that's no longer buffered should have yielded no cause")
 }
 
 func TestNewWithCause(t *testing.T) {
 	cause := buildCause()
 	outer := New("Hello %v", cause)
 	assert.Equal(t, "Hello World", hidden.Clean(outer.Error()))
-	assert.Equal(t, "Hello %v", outer.(*structured).ErrorClean())
+	assert.Equal(t, "Hello %v", outer.ErrorClean())
+	require.IsType(t, (*wrappingError)(nil), outer, "Including an error arg should have resulted in a *wrappingError")
 	assert.Equal(t,
 		"github.com/getlantern/errors.TestNewWithCause (errors_test.go:999)",
-		replaceNumbers.ReplaceAllString(outer.(*structured).data["error_location"].(string), "999"))
-	assert.Equal(t, cause, outer.(*structured).cause)
+		replaceNumbers.ReplaceAllString(outer.(*wrappingError).data["error_location"].(string), "999"))
+	assert.Equal(t, cause, outer.(*wrappingError).wrapped)
 
 	// Make sure that stacktrace prints out okay
 	buf := &bytes.Buffer{}
@@ -123,7 +128,7 @@ func TestHiddenWithCause(t *testing.T) {
 	e2 := New("I wrap: %v", e1)
 	e3 := fmt.Errorf("Hiding %v", e2)
 	// clear hidden buffer
-	hiddenErrors = make([]*structured, 100)
+	hiddenErrors = make([]*baseError, 100)
 	e4 := Wrap(e3)
 	e5 := New("I'm really outer: %v", e4)
 

--- a/errors_test.go
+++ b/errors_test.go
@@ -149,9 +149,10 @@ func TestHiddenWithCause(t *testing.T) {
 func TestFill(t *testing.T) {
 	e := New("something happened").(*baseError)
 	e2 := New("uh oh: %v", e).(*wrappingError)
-	e3 := New("umm: %v", e2).(*wrappingError)
+	e3 := fmt.Errorf("hmm: %w", e2)
+	e4 := New("umm: %v", e3).(*wrappingError)
 
-	e3.data["name"] = "e3"
+	e4.data["name"] = "e4"
 	e2.data["name"] = "e2"
 	e.data["name"] = "e"
 	e2.data["k"] = "v2"
@@ -159,8 +160,8 @@ func TestFill(t *testing.T) {
 	e.data["a"] = "b"
 
 	m := context.Map{}
-	e3.Fill(m)
-	require.Equal(t, "e3", m["name"])
+	e4.Fill(m)
+	require.Equal(t, "e4", m["name"])
 	require.Equal(t, "v2", m["k"])
 	require.Equal(t, "b", m["a"])
 }

--- a/errors_test.go
+++ b/errors_test.go
@@ -146,6 +146,25 @@ func TestHiddenWithCause(t *testing.T) {
 	// doesn't panic. If we get to this point without panicking, we're happy.
 }
 
+func TestFill(t *testing.T) {
+	e := New("something happened").(*baseError)
+	e2 := New("uh oh: %v", e).(*wrappingError)
+	e3 := New("umm: %v", e2).(*wrappingError)
+
+	e3.data["name"] = "e3"
+	e2.data["name"] = "e2"
+	e.data["name"] = "e"
+	e2.data["k"] = "v2"
+	e.data["k"] = "v"
+	e.data["a"] = "b"
+
+	m := context.Map{}
+	e3.Fill(m)
+	require.Equal(t, "e3", m["name"])
+	require.Equal(t, "v2", m["k"])
+	require.Equal(t, "b", m["a"])
+}
+
 // Ensures that this package implements error unwrapping as described in:
 // https://golang.org/pkg/errors/#pkg-overview
 func TestUnwrapping(t *testing.T) {

--- a/errors_test.go
+++ b/errors_test.go
@@ -145,3 +145,25 @@ func TestHiddenWithCause(t *testing.T) {
 	// We're not asserting the output because we're just making sure that printing
 	// doesn't panic. If we get to this point without panicking, we're happy.
 }
+
+// TODO: delete or remove redundant tests elsewhere
+// TODO: remove print statements
+func TestMultilinePrinter(t *testing.T) {
+	e := New("an error occurred")
+	require.IsType(t, (*baseError)(nil), e, "error without cause should be a *baseError")
+	p := e.MultiLinePrinter()
+	buf := new(bytes.Buffer)
+	for p(buf) {
+		fmt.Fprintln(buf)
+	}
+	fmt.Println(buf.String())
+
+	e2 := New("something happened: %v", e)
+	require.IsType(t, (*wrappingError)(nil), e2, "error wrapping another should be a *wrappingError")
+	p2 := e2.MultiLinePrinter()
+	buf = new(bytes.Buffer)
+	for p2(buf) {
+		fmt.Fprintln(buf)
+	}
+	fmt.Println(buf.String())
+}

--- a/errors_test.go
+++ b/errors_test.go
@@ -49,9 +49,7 @@ func TestFull(t *testing.T) {
 	}
 
 	e3 := Wrap(fmt.Errorf("I'm wrapping your text: %v", firstErr)).With("a", 2)
-	// TODO: is this correct? (replaces commented line below)
 	require.IsType(t, (*baseError)(nil), e3, "Wrapping an *Error that's no longer buffered should have resulted in a *baseError")
-	// assert.Nil(t, e3.(*baseError).cause, "Wrapping an *Error that's no longer buffered should have yielded no cause")
 }
 
 func TestNewWithCause(t *testing.T) {
@@ -128,7 +126,7 @@ func TestHiddenWithCause(t *testing.T) {
 	e2 := New("I wrap: %v", e1)
 	e3 := fmt.Errorf("Hiding %v", e2)
 	// clear hidden buffer
-	hiddenErrors = make([]*baseError, 100)
+	hiddenErrors = make([]hideableError, 100)
 	e4 := Wrap(e3)
 	e5 := New("I'm really outer: %v", e4)
 
@@ -143,24 +141,4 @@ func TestHiddenWithCause(t *testing.T) {
 	}
 	// We're not asserting the output because we're just making sure that printing
 	// doesn't panic. If we get to this point without panicking, we're happy.
-}
-
-// TODO: delete or remove redundant tests elsewhere
-// TODO: remove print statements
-func TestMultilinePrinter(t *testing.T) {
-	e := New("an error occurred")
-	require.IsType(t, (*baseError)(nil), e, "error without cause should be a *baseError")
-	p := e.MultiLinePrinter()
-	buf := new(bytes.Buffer)
-	for p(buf) {
-		fmt.Fprintln(buf)
-	}
-
-	e2 := New("something happened: %v", e)
-	require.IsType(t, (*wrappingError)(nil), e2, "error wrapping another should be a *wrappingError")
-	p2 := e2.MultiLinePrinter()
-	buf = new(bytes.Buffer)
-	for p2(buf) {
-		fmt.Fprintln(buf)
-	}
 }

--- a/hide.go
+++ b/hide.go
@@ -8,7 +8,7 @@ import (
 )
 
 var (
-	hiddenErrors = make([]*structured, 100)
+	hiddenErrors = make([]*baseError, 100)
 	nextID       = uint64(0)
 	hiddenMutex  sync.RWMutex
 )
@@ -18,7 +18,7 @@ var (
 // by a standard error using something like
 // fmt.Errorf("An error occurred: %v", thisError), we can subsequently extract
 // the error simply using the hiddenID in the string.
-func (e *structured) save() {
+func (e *baseError) save() {
 	hiddenMutex.Lock()
 	b := make([]byte, 8)
 	binary.BigEndian.PutUint64(b, nextID)

--- a/hide.go
+++ b/hide.go
@@ -8,22 +8,29 @@ import (
 )
 
 var (
-	hiddenErrors = make([]*baseError, 100)
+	hiddenErrors = make([]hideableError, 100)
 	nextID       = uint64(0)
 	hiddenMutex  sync.RWMutex
 )
 
+type hideableError interface {
+	Error
+	id() uint64
+	setID(uint64)
+	setHiddenID(string)
+}
+
 // This trick saves the error to a ring buffer and embeds a non-printing
-// hiddenID in the error's description, so that if the errors is later wrapped
+// hiddenID in the error's description, so that if the error is later wrapped
 // by a standard error using something like
 // fmt.Errorf("An error occurred: %v", thisError), we can subsequently extract
 // the error simply using the hiddenID in the string.
-func (e *baseError) save() {
+func bufferError(e hideableError) {
 	hiddenMutex.Lock()
 	b := make([]byte, 8)
 	binary.BigEndian.PutUint64(b, nextID)
-	e.id = nextID
-	e.hiddenID = hidden.ToString(b)
+	e.setID(nextID)
+	e.setHiddenID(hidden.ToString(b))
 	hiddenErrors[idxForID(nextID)] = e
 	nextID++
 	hiddenMutex.Unlock()
@@ -37,7 +44,7 @@ func get(hiddenID []byte) Error {
 	hiddenMutex.RLock()
 	err := hiddenErrors[idxForID(id)]
 	hiddenMutex.RUnlock()
-	if err != nil && err.id == id {
+	if err != nil && err.id() == id {
 		// Found it!
 		return err
 	}


### PR DESCRIPTION
With this PR, any instances of errors.Error _which have an associated cause_ will implement the method `Unwrap() error`.  Errors with no cause will not implement this method.  This means that `errors.Is` and `errors.As` will work on the errors produced by this package in the same way they would for errors produced by `fmt.Errorf` or `errors.New`.  For concrete examples, see the new test, `TestUnwrapping`.

The public API is completely unchanged, so this can serve as a drop-in replacement.