### PR TITLE
Change the version in go.mod to conform with the changes in Go 1.22

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/getlantern/errors
 
-go 1.0
+go 1.12
 
 require (
 	github.com/getlantern/context v0.0.0-20220418194847-3d5e7a086201


### PR DESCRIPTION
This is needed to resolve the issues with all upstream dependencies. This shouldn’t change anything for the upstream packages.

Sorry making such a tiny change, but the more people will move to Go 1.22, the more issues will pop up.